### PR TITLE
Update Error handling section to handle 201 status

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -281,7 +281,7 @@ $connection->setProxy([
 
 <pre>
 $statues = $connection->post("statuses/update", ["status" => "hello world"]);
-if ($connection->getLastHttpCode() == 200) {
+if (in_array ($connection->getLastHttpCode(), [200, 201])) {
     // Tweet posted successfully
 } else {
     // Handle error case


### PR DESCRIPTION
The API for posting a tweet can return 201 (201 Created) instead of 200, though this is not documented. See: https://twittercommunity.com/t/158443